### PR TITLE
Update renovate config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -46,15 +46,6 @@
       ]
     },
     {
-      // ignore selected deps - they should be bumped by bump of other dep
-      "enabled": false,
-      "matchManagers": ["gomod"],
-      "matchDepTypes": ["direct"],
-      "matchDepNames": [
-        "sigs.k8s.io/structured-merge-diff/v4", // bumped by k8s.io/apimachinery
-      ]
-    },
-    {
       "description": "Single PR for all kubernetes dependency updates, as they usually are all linked",
       "matchDatasources": [
         "go"
@@ -72,6 +63,15 @@
       ],
       "rangeStrategy": "bump",
       "groupName": "golang version"
+    },
+    {
+      // ignore selected deps - they should be bumped by bump of other dep
+      "enabled": false,
+      "matchManagers": ["gomod"],
+      "matchDepTypes": ["direct"],
+      "matchDepNames": [
+        "sigs.k8s.io/structured-merge-diff/v4", // bumped by k8s.io/apimachinery
+      ]
     }
   ],
   "customManagers": [

--- a/.github/workflows/validate-renovate-config.yml
+++ b/.github/workflows/validate-renovate-config.yml
@@ -19,6 +19,6 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
         with:
-          node-version: 20
+          node-version: 22
       - name: Validate Renovate JSON
         run: npx --yes --package renovate -- renovate-config-validator


### PR DESCRIPTION
- move the package rule that disabled updates to the "sigs.k8s.io/structured-merge-diff/v4" dependency lower in the chain, to increase its prio
- bump nodejs version for renovate-bot cli that checks correctness of renovate cfg