### PR TITLE
chore: harden renovate config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -2,12 +2,11 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended",
-    "helpers:pinGitHubActionDigestsToSemver",
-    "group:allNonMajor"
+    "helpers:pinGitHubActionDigestsToSemver"
   ],
   "dependencyDashboard": false,
-  "prConcurrentLimit": 0,
-  "prHourlyLimit": 0,
+  "prConcurrentLimit": 5,
+  "prHourlyLimit": 5,
   // We don't want to separate major and minor upgrades in separate PRs since
   // we can upgrade them together in a single PR.
   "separateMajorMinor": false,
@@ -21,29 +20,27 @@
   "labels": [
     "automated"
   ],
-  "vulnerabilityAlerts": {
-    "enabled": true
-  },
   "osvVulnerabilityAlerts": true,
   "packageRules": [
     {
-      // bump all indirect otel deps
-      "enabled": true,
+      // Group non-major updates by manager so one broken bump doesn't block
+      // unrelated updates, and PRs stay reviewable.
+      "description": "Group non-major go module updates",
       "matchManagers": ["gomod"],
-      "matchDepTypes": ["indirect"],
-      "matchPackagePrefixes": [
-        "go.opentelemetry.io"
-      ]
+      "matchUpdateTypes": ["patch", "minor"],
+      "groupName": "go modules (non-major)"
     },
     {
-      // bump selected indirect k8s deps
-      "enabled": true,
-      "matchManagers": ["gomod"],
-      "matchDepTypes": ["indirect"],
-      "matchDepNames": [
-        "k8s.io/apiextensions-apiserver",
-        "k8s.io/cli-runtime"
-      ]
+      "description": "Group non-major GitHub Actions updates",
+      "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["patch", "minor"],
+      "groupName": "github actions (non-major)"
+    },
+    {
+      "description": "Group non-major updates from custom managers (Makefile, workflows, Go)",
+      "matchManagers": ["custom.regex"],
+      "matchUpdateTypes": ["patch", "minor"],
+      "groupName": "tooling (non-major)"
     },
     {
       "description": "Single PR for all kubernetes dependency updates, as they usually are all linked",
@@ -76,30 +73,31 @@
   ],
   "customManagers": [
     {
+      // Handles version variables in GitHub workflows. Both styles are
+      // supported:
+      //   # renovate: datasource=... depName=...
+      //   FOO_VERSION: 1.2.3
+      // and
+      //   FOO_VERSION: 1.2.3 # renovate: datasource=... depName=...
+      // (renovate ships this as the `customManagers:githubActionsVersions`
+      // preset - if this rule changes, mirror the upstream preset regex.)
       "customType": "regex",
       "description": "Update `version:` and `_VERSION:` variables in github workflows",
       "fileMatch": [
         "^\\.github/workflows/[^/]+\\.ya?ml$"
       ],
       "matchStrings": [
-        "\\s+[A-Za-z0-9_]+?-version: (?<currentValue>.+?) # renovate: datasource=(?<datasource>.+?) depName=(?<depName>.+?)(?: (?:packageName|lookupName)=(?<packageName>.+?))?(?: versioning=(?<versioning>.+?))?\\s",
-        "\\s*[A-Z0-9_]+?_VERSION: (?<currentValue>.+?) # renovate: datasource=(?<datasource>.+?) depName=(?<depName>.+?)(?: (?:packageName|lookupName)=(?<packageName>.+?))?(?: versioning=(?<versioning>.+?))?\\s"
+        // annotation on the line above the variable
+        "\\s*# renovate: datasource=(?<datasource>[a-z-.]+?) depName=(?<depName>[^\\s]+?)(?: (?:packageName|lookupName)=(?<packageName>[^\\s]+?))?(?: versioning=(?<versioning>[^\\s]+?))?(?: extractVersion=(?<extractVersion>[^\\s]+?))?\\s+[A-Za-z0-9_]+?(?:-version|_VERSION)\\s*:\\s*[\"']?(?<currentValue>.+?)[\"']?\\s",
+        // annotation on the same line, after the value
+        "\\s+[A-Za-z0-9_]+?(?:-version|_VERSION):\\s*[\"']?(?<currentValue>.+?)[\"']?[ \t]+# renovate: datasource=(?<datasource>[a-z-.]+?) depName=(?<depName>[^\\s]+?)(?: (?:packageName|lookupName)=(?<packageName>[^\\s]+?))?(?: versioning=(?<versioning>[^\\s]+?))?\\s"
       ]
     },
     {
-      // https://docs.renovatebot.com/presets-customManagers/#custommanagersgithubactionsversions
+      // Handles `VAR_VERSION ?= value` variables in Makefiles.
+      // renovate ships this as the `customManagers:makefileVersions` preset.
       "customType": "regex",
-      "fileMatch": [
-        "(^|/)(workflow-templates|\\.(?:github|gitea|forgejo)/(?:workflows|actions))/.+\\.ya?ml$",
-        "(^|/)action\\.ya?ml$"
-      ],
-      "matchStrings": [
-        "# renovate: datasource=(?<datasource>[a-z-.]+?) depName=(?<depName>[^\\s]+?)(?: (?:lookupName|packageName)=(?<packageName>[^\\s]+?))?(?: versioning=(?<versioning>[^\\s]+?))?(?: extractVersion=(?<extractVersion>[^\\s]+?))?\\s+[A-Za-z0-9_]+?_VERSION\\s*:\\s*[\"']?(?<currentValue>.+?)[\"']?\\s"
-      ]
-    },
-    {
-      // https://docs.renovatebot.com/presets-customManagers/#custommanagersmakefileversions
-      "customType": "regex",
+      "description": "Update `_VERSION` variables in Makefiles",
       "fileMatch": [
         "(^|/)Makefile$",
         "(^|/)makefile$",
@@ -113,6 +111,7 @@
     {
       // thanks cilium :*
       "customType": "regex",
+      "description": "Update image/version constants in Go files",
       "fileMatch": [
         "\\.go$"
       ],
@@ -123,8 +122,10 @@
     }
   ],
   "postUpgradeTasks": {
+    // regenerate manifests/deepcopy so the CRDs and generated code stay in
+    // sync after dependency updates - nothing heavier
     "commands": [
-      "make"
+      "make generate"
     ],
     "executionMode": "branch"
   }

--- a/.github/workflows/validate-renovate-config.yml
+++ b/.github/workflows/validate-renovate-config.yml
@@ -6,6 +6,10 @@ name: Validate Renovate Config
   pull_request:
     paths:
       - .github/renovate.json5
+      - .github/workflows/*.yaml
+      - hack/check-renovate-managers.mjs
+      - Makefile
+      - internal/defaults/**
 
 concurrency:
   cancel-in-progress: true
@@ -22,3 +26,5 @@ jobs:
           node-version: 24
       - name: Validate Renovate JSON
         run: npx --yes --package renovate -- renovate-config-validator
+      - name: Check custom managers match repo annotations
+        run: node hack/check-renovate-managers.mjs

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
+# renovate: datasource=github-releases depName=kubernetes/kubernetes extractVersion=^v(?<version>\d+\.\d+)
 ENVTEST_K8S_VERSION = 1.33
 KO_DOCKER_REPO ?= ko.local
 CURRENT_DIR = $(dir $(abspath $(firstword $(MAKEFILE_LIST))))

--- a/hack/check-renovate-managers.mjs
+++ b/hack/check-renovate-managers.mjs
@@ -1,0 +1,209 @@
+#!/usr/bin/env node
+// Verifies that every regex custom manager in .github/renovate.json5 actually
+// matches the dependency annotations it is expected to manage in this repo.
+//
+// Custom manager regexes fail silently: if an annotation moves one line away
+// from where the regex expects it (or the regex changes), Renovate simply
+// stops updating that dependency and nothing in CI complains. This script
+// turns that into a CI failure.
+//
+// Run: node hack/check-renovate-managers.mjs
+
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { dirname, join, relative, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const configFile = process.argv[2]
+  ? resolve(process.argv[2])
+  : join(root, '.github', 'renovate.json5');
+
+// Minimal JSON5 -> JSON: strips comments and trailing commas, string-aware.
+const isWhitespace = (c) => c === ' ' || c === '\t' || c === '\n' || c === '\r';
+
+function stripComments(src) {
+  let out = '';
+  let inString = false;
+  let i = 0;
+  while (i < src.length) {
+    const c = src[i];
+    const next = src[i + 1];
+    if (inString) {
+      out += c;
+      if (c === '\\' && next !== undefined) {
+        out += next;
+        i += 2;
+        continue;
+      }
+      if (c === '"') inString = false;
+      i += 1;
+      continue;
+    }
+    if (c === '"') {
+      inString = true;
+      out += c;
+      i += 1;
+      continue;
+    }
+    if (c === '/' && next === '/') {
+      while (i < src.length && src[i] !== '\n') i += 1;
+      continue;
+    }
+    if (c === '/' && next === '*') {
+      i += 2;
+      while (i < src.length && !(src[i] === '*' && src[i + 1] === '/')) i += 1;
+      i += 2;
+      continue;
+    }
+    out += c;
+    i += 1;
+  }
+  return out;
+}
+
+function stripTrailingCommas(src) {
+  let out = '';
+  let inString = false;
+  let i = 0;
+  while (i < src.length) {
+    const c = src[i];
+    const next = src[i + 1];
+    if (inString) {
+      out += c;
+      if (c === '\\' && next !== undefined) {
+        out += next;
+        i += 2;
+        continue;
+      }
+      if (c === '"') inString = false;
+      i += 1;
+      continue;
+    }
+    if (c === '"') {
+      inString = true;
+      out += c;
+      i += 1;
+      continue;
+    }
+    if (c === ',') {
+      let j = i + 1;
+      while (j < src.length && isWhitespace(src[j])) j += 1;
+      if (src[j] === '}' || src[j] === ']') {
+        i += 1;
+        continue;
+      }
+    }
+    out += c;
+    i += 1;
+  }
+  return out;
+}
+
+function toJson(src) {
+  return stripTrailingCommas(stripComments(src));
+}
+
+const config = JSON.parse(toJson(readFileSync(configFile, 'utf8')));
+
+function walk(dir, files = []) {
+  for (const entry of readdirSync(dir)) {
+    if (entry === '.git' || entry === 'node_modules' || entry === 'bin') continue;
+    const p = join(dir, entry);
+    const st = statSync(p);
+    if (st.isDirectory()) walk(p, files);
+    else files.push(p);
+  }
+  return files;
+}
+
+const files = walk(root);
+
+const found = [];
+for (const cm of config.customManagers ?? []) {
+  if (cm.customType !== 'regex') continue;
+  const fileRegexes = (cm.fileMatch ?? []).map((p) => new RegExp(p));
+  const matchRegexes = (cm.matchStrings ?? []).map((p) => new RegExp(p, 'g'));
+  for (const file of files) {
+    const rel = relative(root, file);
+    if (!fileRegexes.some((re) => re.test(rel))) continue;
+    const content = readFileSync(file, 'utf8');
+    for (const re of matchRegexes) {
+      for (const m of content.matchAll(re)) {
+        const g = m.groups ?? {};
+        found.push({
+          depName: g.depName,
+          datasource: g.datasource,
+          currentValue: g.currentValue,
+          file: rel,
+        });
+      }
+    }
+  }
+}
+
+// [datasource, depName, minMatches]. currentValue is intentionally not
+// asserted: versions move constantly and the guard would go stale on every
+// renovate bump. Presence (and, where the same dep is annotated in several
+// files, count) is what catches silent regex regressions.
+const expected = [
+  ['github-releases', 'golangci/golangci-lint', 2], // Makefile + ci.yaml env
+  ['github-releases', 'kubernetes-sigs/kind'],
+  ['github-releases', 'kubernetes-sigs/controller-tools'],
+  ['github-releases', 'ko-build/ko'],
+  ['github-releases', 'gotestyourself/gotestsum'],
+  ['go', 'github.com/kubernetes/code-generator'],
+  ['go', 'github.com/kyverno/chainsaw'],
+  ['github-releases', 'kubernetes/kubernetes'], // ENVTEST_K8S_VERSION
+  ['docker', 'renovate'],
+  ['docker', 'docker.io/ollama/ollama'],
+];
+
+let ok = true;
+if (process.env.DEBUG) {
+  console.error('found deps:');
+  for (const f of found) {
+    console.error(`  ${f.file}: ${f.datasource} ${f.depName} = ${f.currentValue}`);
+  }
+}
+
+// Guard against cross-line mis-associations: a single annotation in a file
+// must resolve to exactly one value. If two different currentValues end up on
+// the same (file, depName), the regex is matching across the wrong lines and
+// renovate would produce a garbage dependency.
+const byFileAndDep = new Map();
+for (const f of found) {
+  const key = `${f.file} :: ${f.depName}`;
+  if (!byFileAndDep.has(key)) byFileAndDep.set(key, new Set());
+  byFileAndDep.get(key).add(f.currentValue);
+}
+for (const [key, values] of byFileAndDep) {
+  if (values.size > 1) {
+    ok = false;
+    console.error(
+      `FAIL: ${key} resolves to ${values.size} different values: ${[...values].join(', ')}`,
+    );
+  }
+}
+
+for (const [datasource, depName, min = 1] of expected) {
+  const matches = found.filter(
+    (f) => f.datasource === datasource && f.depName === depName,
+  );
+  if (matches.length < min) {
+    ok = false;
+    console.error(
+      `FAIL: expected ${min} match(es) for ${datasource} ${depName}, found ${matches.length}`,
+    );
+    for (const f of found.filter((f) => f.depName === depName)) {
+      console.error(`  found in ${f.file}: datasource=${f.datasource} currentValue=${f.currentValue}`);
+    }
+  }
+}
+
+if (ok) {
+  console.log(
+    `OK: all ${expected.length} expected dependency annotations matched (${found.length} custom-manager deps found)`,
+  );
+} else {
+  process.exit(1);
+}


### PR DESCRIPTION
- group non-major updates per manager instead of one mega PR
- limit concurrent/hourly PRs to 5
- run only 'make generate' post-upgrade instead of full make
- drop no-op indirect-dep rules and legacy vulnerabilityAlerts
- merge workflow version custom managers into one
- annotate ENVTEST_K8S_VERSION for renovate
- add guard that checks custom managers still match repo annotations