### PR TITLE
ci: pin helm version for renovate

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,6 +13,8 @@ env:
   GOLANGCI_LINT_VERSION: v2.7.2
   # renovate: datasource=github-releases depName=kubernetes-sigs/kind
   KIND_VERSION: v0.28.0
+  # renovate: datasource=github-releases depName=helm/helm
+  HELM_VERSION: v4.1.4
   # bump this manually when the kind version changes!
   KIND_NODE_IMAGE: kindest/node:v1.31.0@sha256:53df588e04085fd41ae12de0c3fe4c72f7013bba32a20e7325357a1ac94ba865
 
@@ -97,6 +99,8 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Setup Helm binary
         uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
+        with:
+          version: ${{ env.HELM_VERSION }}
       - name: Login to ghcr with Helm
         run: |
           helm registry login ghcr.io -u ${{ github.repository_owner }} -p ${{ secrets.GITHUB_TOKEN }}
@@ -114,6 +118,8 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Setup helm
         uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
+        with:
+          version: ${{ env.HELM_VERSION }}
       - name: Install chainsaw
         uses: kyverno/action-install-chainsaw@f2b47b97dc889c12702113753d713f01ec268de5 # v0.2.12
       - name: Create k8s Kind Cluster


### PR DESCRIPTION
Pin Helm to v4.1.4 (second-to-last minor) via `HELM_VERSION` with a renovate comment so Renovate opens a PR when a newer Helm release is available.

- Adds `HELM_VERSION` env var with `renovate: datasource=github-releases depName=helm/helm` comment
- Wires `version: ${{ env.HELM_VERSION }}` into both `azure/setup-helm` steps