### PR TITLE
ci: keep KIND_NODE_IMAGE in sync with KIND_VERSION

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -125,7 +125,11 @@
     // regenerate manifests/deepcopy so the CRDs and generated code stay in
     // sync after dependency updates - nothing heavier
     "commands": [
-      "make generate"
+      "make generate",
+      // keep KIND_NODE_IMAGE pinned to an image actually shipped for the
+      // KIND_VERSION in ci.yaml (the release notes list the supported images).
+      // The script is a no-op when the image is already supported.
+      "./hack/update-kind-node-image.sh"
     ],
     "executionMode": "branch"
   }

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,7 @@ env:
   KIND_VERSION: v0.28.0
   # renovate: datasource=github-releases depName=helm/helm
   HELM_VERSION: v4.1.4
-  # bump this manually when the kind version changes!
+  # kept in sync with KIND_VERSION by hack/update-kind-node-image.sh (runs as a renovate postUpgradeTask)
   KIND_NODE_IMAGE: kindest/node:v1.31.0@sha256:53df588e04085fd41ae12de0c3fe4c72f7013bba32a20e7325357a1ac94ba865
 
 jobs:

--- a/hack/update-kind-node-image.sh
+++ b/hack/update-kind-node-image.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Updates KIND_NODE_IMAGE in .github/workflows/ci.yaml to a node image that is
+# actually shipped for the KIND_VERSION pinned there. The kind -> node image
+# mapping only exists in the kind release notes, so this script fetches the
+# notes for the pinned kind version and parses the images listed there.
+#
+# The script is idempotent: it leaves the image untouched when it is already
+# one of the images listed for the current KIND_VERSION (including when the
+# user intentionally pinned an older, still-supported image), and otherwise
+# rewrites it to the release's default image.
+#
+# It runs as a Renovate postUpgradeTask so KIND_NODE_IMAGE is bumped in the
+# same PR that bumps KIND_VERSION. It can also be run manually:
+#   ./hack/update-kind-node-image.sh [path/to/ci.yaml]
+
+REPO_ROOT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." &> /dev/null && pwd )"
+CI_FILE="${1:-${REPO_ROOT_DIR}/.github/workflows/ci.yaml}"
+
+python3 - "${CI_FILE}" <<'PY'
+import json
+import re
+import sys
+import urllib.request
+
+ci_file = sys.argv[1]
+
+with open(ci_file) as f:
+    content = f.read()
+
+
+def var(name):
+    m = re.search(rf'^[ \t]*{name}:\s*(.+?)\s*$', content, re.MULTILINE)
+    if not m:
+        sys.exit(f'error: could not find {name} in {ci_file}')
+    return m.group(1).strip("\"'")
+
+
+kind_version = var('KIND_VERSION')
+current_image = var('KIND_NODE_IMAGE')
+
+url = f'https://api.github.com/repos/kubernetes-sigs/kind/releases/tags/{kind_version}'
+req = urllib.request.Request(url, headers={'User-Agent': 'ollama-operator-renovate'})
+try:
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        release = json.load(resp)
+except Exception as e:  # noqa: BLE001
+    sys.exit(f'error: failed to fetch kind {kind_version} release notes from {url}: {e}')
+
+# The release notes list the images pre-built for this release as:
+#   - v1.33.1: `kindest/node:v1.33.1@sha256:8d866994839c...`
+# The first occurrence is the release's default node image.
+images = re.findall(r'kindest/node:v\d+\.\d+\.\d+@sha256:[a-f0-9]{64}', release.get('body', ''))
+if not images:
+    sys.exit(f'error: no node images found in kind {kind_version} release notes')
+
+default_image = images[0]
+
+if current_image == default_image:
+    print(f'KIND_NODE_IMAGE is already the default for kind {kind_version}: {current_image}')
+    sys.exit(0)
+
+if current_image in images:
+    print(f'KIND_NODE_IMAGE {current_image} is still supported by kind {kind_version}, leaving unchanged')
+    sys.exit(0)
+
+new_content = re.sub(
+    r'^(?P<indent>[ \t]*)KIND_NODE_IMAGE:\s*.*$',
+    lambda m: f"{m.group('indent')}KIND_NODE_IMAGE: {default_image}",
+    content,
+    count=1,
+    flags=re.MULTILINE,
+)
+with open(ci_file, 'w') as f:
+    f.write(new_content)
+
+print(f'Updated KIND_NODE_IMAGE: {current_image} -> {default_image} (default for kind {kind_version})')
+PY


### PR DESCRIPTION
When `KIND_VERSION` is bumped, `KIND_NODE_IMAGE` needs to follow, but the node image tag is a *Kubernetes* version rather than a kind version and the kind → node-image mapping only exists in the kind release notes. Previously this was a manual step (and was already stale: kind v0.28.0 ships v1.33.1, not v1.31.0).

## Changes

- **`hack/update-kind-node-image.sh`** (new): reads `KIND_VERSION` from `.github/workflows/ci.yaml`, fetches the kind release notes for that version from the GitHub API, parses the `kindest/node:v…@sha256:…` references, and pins `KIND_NODE_IMAGE` to an image actually shipped for that kind release. It is idempotent:
  - leaves the image untouched if it is already one of the images listed for the current `KIND_VERSION` (an intentionally pinned older, still-supported image is preserved)
  - otherwise rewrites it to the release's default image
- **`.github/renovate.json5`**: runs the script as a Renovate `postUpgradeTask`, so the node image is bumped in the same PR that bumps `KIND_VERSION`
- **`.github/workflows/ci.yaml`**: comment updated

The script only needs `python3` (present in the `renovatebot/renovate:full` image).

Note: the current image (`v1.31.0`) is not shipped by kind v0.28.0, so the next Renovate run will correct it to `v1.33.1`.