### PR TITLE
fix: bump golangci-lint and chainsaw for Go 1.26

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,7 @@ name: CI
 
 env:
   # renovate: datasource=github-releases depName=golangci/golangci-lint
-  GOLANGCI_LINT_VERSION: v2.7.2
+  GOLANGCI_LINT_VERSION: v2.12.2
   # renovate: datasource=github-releases depName=kubernetes-sigs/kind
   KIND_VERSION: v0.28.0
   # renovate: datasource=github-releases depName=helm/helm

--- a/Makefile
+++ b/Makefile
@@ -111,7 +111,7 @@ CHAINSAW = $(LOCALBIN)/chainsaw
 CONTROLLER_TOOLS_VERSION ?= v0.18.0
 ENVTEST_VERSION ?= release-0.20
 # renovate: datasource=github-releases depName=golangci/golangci-lint
-GOLANGCI_LINT_VERSION ?= v2.7.2
+GOLANGCI_LINT_VERSION ?= v2.12.2
 # renovate: datasource=github-releases depName=ko-build/ko
 KO_VERSION ?= v0.18.0
 # renovate: datasource=github-releases depName=gotestyourself/gotestsum
@@ -119,7 +119,7 @@ GOTESTSUM_VERSION ?= v1.13.0
 # renovate: datasource=go depName=github.com/kubernetes/code-generator
 CODE_GENERATOR_VERSION ?= v0.33.1
 # renovate: datasource=go depName=github.com/kyverno/chainsaw
-CHAINSAW_VERSION ?= v0.2.12
+CHAINSAW_VERSION ?= v0.2.15
 
 .PHONY: controller-gen
 controller-gen: $(CONTROLLER_GEN) ## Download controller-gen locally if necessary.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module aerf.io/ollama-operator
 
-go 1.25.5
+go 1.26.5
 
 require (
 	aerf.io/k8sutils v0.0.0-20250522105104-912729bc10f3

--- a/internal/testutils/cmp.go
+++ b/internal/testutils/cmp.go
@@ -7,7 +7,8 @@ import (
 )
 
 func IgnoreXPv1ConditionFields(additionalIgnoredFields ...string) cmp.Option {
-	ignoredFields := []string{"LastTransitionTime", "ObservedGeneration"}
+	ignoredFields := make([]string, 0, 2+len(additionalIgnoredFields))
+	ignoredFields = append(ignoredFields, "LastTransitionTime", "ObservedGeneration")
 	ignoredFields = append(ignoredFields, additionalIgnoredFields...)
 	return cmpopts.IgnoreFields(xpv1.Condition{}, ignoredFields...)
 }


### PR DESCRIPTION
Prerequisite for the `go 1.26.5` bump in renovate PR #174 — its CI fails because the pinned tooling predates Go 1.26:

- **golangci-lint `v2.7.2` → `v2.12.2`** (`ci.yaml` + `Makefile`): v2.7.2 is built with go1.25, and golangci-lint refuses to run when `go.mod` targets a newer Go version than the binary was built with ("the Go language version (go1.25) used to build golangci-lint is lower than the targeted Go version (1.26.5)").
- **chainsaw `v0.2.12` → `v0.2.15`** (`Makefile`): v0.2.12 does not compile under Go 1.26 (`testing.MainStart` gained a `ModulePath` parameter).
- **`internal/testutils/cmp.go`**: preallocate the slice to satisfy the newer `prealloc` check in golangci-lint v2.12.2.

All CI checks verified locally (golangci-lint v2.12.2: 0 issues, chainsaw v0.2.15: config lint passes).