### PR TITLE
fix: use explicit depName annotation for Go image constants

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -109,15 +109,17 @@
       ]
     },
     {
-      // thanks cilium :*
+      // Same annotation convention as the workflow variables above, but for Go
+      // constants (e.g. internal/defaults/defaults.go):
+      //   // renovate: datasource=docker depName=docker.io/ollama/ollama
+      //   OllamaImage = "docker.io/ollama/ollama:0.7.0"
       "customType": "regex",
-      "description": "Update image/version constants in Go files",
+      "description": "Update image constants in Go files",
       "fileMatch": [
         "\\.go$"
       ],
       "matchStrings": [
-        ".+?renovate: datasource=(?<datasource>.*?)\\s+.+Image = \"(?<depName>.*):(?<currentValue>.*)\"",
-        ".+?renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)\\s+Version = \"(?<currentValue>.*)\""
+        "\\s*// renovate: datasource=(?<datasource>[a-z-.]+?) depName=(?<depName>[^\\s]+?)(?: (?:packageName|lookupName)=(?<packageName>[^\\s]+?))?(?: versioning=(?<versioning>[^\\s]+?))?(?: extractVersion=(?<extractVersion>[^\\s]+?))?\\s+[A-Za-z0-9_]+?Image\\s*=\\s*[\"'][^:]+:(?<currentValue>[^\"']+)[\"']\\s"
       ]
     }
   ],

--- a/internal/defaults/defaults.go
+++ b/internal/defaults/defaults.go
@@ -1,7 +1,7 @@
 package defaults
 
 const (
-	// renovate: datasource=docker
+	// renovate: datasource=docker depName=docker.io/ollama/ollama
 	OllamaImage = "docker.io/ollama/ollama:0.7.0"
 
 	OllamaPort = 11434


### PR DESCRIPTION
Make renovate update `internal/defaults/defaults.go` reliably by using the same annotation convention as the workflow/YAML files:

- `internal/defaults/defaults.go` now uses `// renovate: datasource=docker depName=docker.io/ollama/ollama` instead of relying on the regex to infer `depName` from the image value.
- The Go custom-manager regex in `.github/renovate.json5` now reads the explicit `depName=` annotation (mirroring the workflow manager), removing the fragile `.+Image = "..."` inference.

Verified with `hack/check-renovate-managers.mjs` and `renovate-config-validator`.