### PR TITLE
fix: migrate event recorder to new events API

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,10 @@ Kubernetes operator that reconciles `Model` and `Prompt` custom resources agains
 
 CI also runs `go mod tidy -diff` and `git diff --exit-code` after `make test`/`make build`, so keep go.mod tidy and commit regenerated output.
 
+## Go codebase exploration
+
+- Prefer the **gopls MCP server** (configured in `opencode.json`) and **`go doc <pkg>.<sym>`** to explore Go code (including dependencies). Do **not** read files directly in `GOMODCACHE` — use `go doc` and gopls instead.
+
 ## Architecture
 
 - `apis/ollama/v1alpha1/` — `Model` and `Prompt` types + generated applyconfiguration/deepcopy. `gvk.go` defines `ModelGroupVersionKind`/`PromptGroupVersionKind`.

--- a/internal/controllers/model/model_controller.go
+++ b/internal/controllers/model/model_controller.go
@@ -44,7 +44,7 @@ import (
 	applyappsv1 "k8s.io/client-go/applyconfigurations/apps/v1"
 	applycorev1 "k8s.io/client-go/applyconfigurations/core/v1"
 	applymetav1 "k8s.io/client-go/applyconfigurations/meta/v1"
-	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/tools/events"
 	"k8s.io/kubectl/pkg/cmd/util/podcmd"
 	"k8s.io/kubectl/pkg/polymorphichelpers"
 	"k8s.io/utils/ptr"
@@ -67,7 +67,7 @@ import (
 
 type Reconciler struct {
 	client               client.Client
-	recorder             record.EventRecorder
+	recorder             events.EventRecorder
 	baseHTTPClient       *http.Client
 	tp                   trace.TracerProvider
 	ollamaClientProvider ollamaclient.ClientProvider
@@ -155,7 +155,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, model *ollamav1alpha1.Model)
 		}
 
 		log.V(1).Info("started pulling ollama model")
-		recorder.NormalEventf("PullingModel", "Pulling %q model", model.Spec.Model)
+		recorder.NormalEventf("PullingModel", "PullingModel", "Pulling %q model", model.Spec.Model)
 
 		pullResp := ollamaapi.ProgressResponse{}
 
@@ -176,7 +176,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, model *ollamav1alpha1.Model)
 
 			return ctx.Err() // return early on context cancel/timeout
 		}); err != nil {
-			recorder.WarningEventf("PullingModel", "failed to pull %q model", model.Spec.Model)
+			recorder.WarningEventf("PullingModel", "PullingModel", "failed to pull %q model", model.Spec.Model)
 			return ctrl.Result{}, errors.Wrapf(err, "failed to pull %q model", model.Spec.Model)
 		}
 		log.V(1).Info("pulled model", "response", pullResp)
@@ -247,7 +247,7 @@ func isStatefulSetReady(sts *appsv1.StatefulSet) (string, bool, error) {
 	return strings.TrimSuffix(msg, "...\n"), ready, nil
 }
 
-func newReconciler(cli client.Client, recorder record.EventRecorder, baseHTTPClient *http.Client, tp trace.TracerProvider) *Reconciler {
+func newReconciler(cli client.Client, recorder events.EventRecorder, baseHTTPClient *http.Client, tp trace.TracerProvider) *Reconciler {
 	return &Reconciler{
 		client:               cli,
 		recorder:             recorder,
@@ -259,7 +259,7 @@ func newReconciler(cli client.Client, recorder record.EventRecorder, baseHTTPCli
 }
 
 func SetupWithManager(mgr ctrl.Manager, baseHTTPClient *http.Client, tp trace.TracerProvider) error {
-	r := newReconciler(mgr.GetClient(), mgr.GetEventRecorderFor("ollama-operator.model-controller"), baseHTTPClient, tp)
+	r := newReconciler(mgr.GetClient(), mgr.GetEventRecorder("ollama-operator.model-controller"), baseHTTPClient, tp)
 	reconciler := reconcile.AsReconciler(mgr.GetClient(), r)
 	reconciler = utilreconcilers.NewWithTracingReconciler(
 		reconciler,

--- a/internal/controllers/model/model_controller_test.go
+++ b/internal/controllers/model/model_controller_test.go
@@ -141,7 +141,7 @@ func TestReconciler_Reconcile(t *testing.T) {
 			&addGVKReconciler{
 				inner: &Reconciler{
 					client:         client.WithFieldOwner(cli, "ollama-operator"),
-					recorder:       record.NewFakeRecorder(1000),
+					recorder:       record.NewEventRecorderAdapter(record.NewFakeRecorder(1000)),
 					baseHTTPClient: &http.Client{},
 					tp:             noop.NewTracerProvider(),
 					ollamaClientProvider: &ollamaclient.TestOllamaClientProvider{

--- a/internal/controllers/prompt/prompt_controller.go
+++ b/internal/controllers/prompt/prompt_controller.go
@@ -23,7 +23,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/tools/events"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -40,12 +40,12 @@ import (
 
 type Reconciler struct {
 	client               client.Client
-	recorder             record.EventRecorder
+	recorder             events.EventRecorder
 	baseHTTPClient       *http.Client
 	ollamaClientProvider ollamaclient.ClientProvider
 }
 
-func newReconciler(cli client.Client, recorder record.EventRecorder, httpCli *http.Client, tp trace.TracerProvider) *Reconciler {
+func newReconciler(cli client.Client, recorder events.EventRecorder, httpCli *http.Client, tp trace.TracerProvider) *Reconciler {
 	return &Reconciler{
 		client:               cli,
 		recorder:             recorder,
@@ -55,7 +55,7 @@ func newReconciler(cli client.Client, recorder record.EventRecorder, httpCli *ht
 }
 
 func SetupWithManager(mgr ctrl.Manager, baseHTTPClient *http.Client, tp trace.TracerProvider) error {
-	r := newReconciler(mgr.GetClient(), mgr.GetEventRecorderFor("ollama-operator.prompt-controller"), baseHTTPClient, tp)
+	r := newReconciler(mgr.GetClient(), mgr.GetEventRecorder("ollama-operator.prompt-controller"), baseHTTPClient, tp)
 	reconciler := reconcile.AsReconciler(mgr.GetClient(), r)
 	reconciler = utilreconcilers.RequeueOnConflict(reconciler)
 	reconciler = utilreconcilers.NewWithTracingReconciler(

--- a/internal/eventrecorder/eventrecorder.go
+++ b/internal/eventrecorder/eventrecorder.go
@@ -3,33 +3,33 @@ package eventrecorder
 import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/tools/events"
 )
 
 type EventRecorder struct {
-	recorder record.EventRecorder
+	recorder events.EventRecorder
 	obj      runtime.Object
 }
 
-func New(recorder record.EventRecorder, obj runtime.Object) *EventRecorder {
+func New(recorder events.EventRecorder, obj runtime.Object) *EventRecorder {
 	return &EventRecorder{
 		recorder: recorder,
 		obj:      obj,
 	}
 }
 
-func (e *EventRecorder) NormalEvent(reason, message string) {
-	e.recorder.Event(e.obj, corev1.EventTypeNormal, reason, message)
+func (e *EventRecorder) NormalEvent(action, reason, message string) {
+	e.recorder.Eventf(e.obj, nil, corev1.EventTypeNormal, reason, action, message)
 }
 
-func (e *EventRecorder) NormalEventf(reason, format string, args ...any) {
-	e.recorder.Eventf(e.obj, corev1.EventTypeNormal, reason, format, args...)
+func (e *EventRecorder) NormalEventf(action, reason, format string, args ...any) {
+	e.recorder.Eventf(e.obj, nil, corev1.EventTypeNormal, reason, action, format, args...)
 }
 
-func (e *EventRecorder) WarningEvent(reason, message string) {
-	e.recorder.Event(e.obj, corev1.EventTypeWarning, reason, message)
+func (e *EventRecorder) WarningEvent(action, reason, message string) {
+	e.recorder.Eventf(e.obj, nil, corev1.EventTypeWarning, reason, action, message)
 }
 
-func (e *EventRecorder) WarningEventf(reason, format string, args ...any) {
-	e.recorder.Eventf(e.obj, corev1.EventTypeWarning, reason, format, args...)
+func (e *EventRecorder) WarningEventf(action, reason, format string, args ...any) {
+	e.recorder.Eventf(e.obj, nil, corev1.EventTypeWarning, reason, action, format, args...)
 }

--- a/opencode.json
+++ b/opencode.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "gopls": {
+      "type": "local",
+      "command": ["gopls", "mcp"],
+      "enabled": true
+    }
+  }
+}


### PR DESCRIPTION
GetEventRecorderFor is deprecated (SA1019); switch to GetEventRecorder
and the k8s.io/client-go/tools/events interface.
